### PR TITLE
Add trait implementation for Serde structs for use as Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,12 @@ redis = { version = "0.7.0", optional = true }
 r2d2_redis = { version = "0.5.0", optional = true }
 r2d2 = { version = "0.7.1", optional = true }
 
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
+
 [features]
 redis-backend = ["redis", "r2d2_redis", "r2d2"]
+serde-values = ["serde", "serde_json"]
 
 [dev-dependencies]
 router = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub trait Key {
     fn get_key() -> &'static str;
 }
 
+#[cfg(feature = "serde-values")]
 impl<T> Value for T
 where
     T: 'static + Key + serde::Serialize + serde::de::DeserializeOwned,


### PR DESCRIPTION
I'm using this like this...

```rust
use iron_sessionstorage;
use uuid::Uuid;

#[derive(Serialize, Deserialize)]
pub struct UserSession {
    session_id: Uuid,
}
impl UserSession {
    pub fn new_with_random_id() -> UserSession {
        UserSession {
            session_id: Uuid::new_v4(),
        }
    }
}
impl iron_sessionstorage::Key for UserSession {
    fn get_key() -> &'static str {
        "user_session"
    }
}

...

pub fn auth_post_handler(req: &mut Request) -> IronResult<Response> {
    let form = req.get::<bodyparser::Struct<AuthForm>>();
    match form {
        Ok(Some(form)) => if form.password == ADMIN_PASSWORD {
            match req.session().get::<UserSession>()? {
                None => {
                    req.session().set(UserSession::new_with_random_id())?;
                }
                _ => {}
            }
            return Ok(Response::with(status::Ok));
        } else {
            return Ok(Response::with(status::Unauthorized));
        },
        _ => return Ok(Response::with(status::BadRequest)),
    }
}

```