### PR TITLE
Update cookie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://github.com/iron/iron-sessionstorage"
 
 [dependencies]
 iron = "0.6"
-cookie = { version = "0.5.0", features = ["secure"] }
+cookie = { version = "0.12.0", features = ["secure"] }
 error-chain = "0.11"
 rand = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iron-sessionstorage"
-version = "0.6.6"
+version = "0.7.0"
 
 authors = ["Markus Unterwaditzer <markus@unterwaditzer.net>"]
 license = "MIT"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -35,7 +35,7 @@ fn handler(req: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    let my_secret = b"verysecret".to_vec();
+    let my_secret = b"verysecretkeyatleast32byteslong.".to_vec();
     let mut ch = Chain::new(handler);
     ch.link_around(SessionStorage::new(SignedCookieBackend::new(my_secret)));
     let _res = Iron::new(ch).http("localhost:8080");

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -89,7 +89,7 @@ fn main() {
         logout: post "/logout" => logout,
     );
 
-    let my_secret = b"verysecret".to_vec();
+    let my_secret = b"verysecretkeyatleast32byteslong.".to_vec();
     let mut ch = Chain::new(router);
     ch.link_around(SessionStorage::new(SignedCookieBackend::new(my_secret)));
     let _res = Iron::new(ch).http("localhost:8080");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,11 +132,11 @@ impl<'a, 'b> SessionRequestExt for Request<'a, 'b> {
     }
 }
 
-fn get_default_cookie(key: String, value: String) -> cookie::Cookie {
-    let mut rv = cookie::Cookie::new(key, value);
-    rv.httponly = true;
-    rv.path = Some("/".to_owned());
-    rv
+fn get_default_cookie(key: String, value: String) -> cookie::Cookie<'static> {
+    cookie::Cookie::build(key, value)
+        .http_only(true)
+        .path("/")
+        .finish()
 }
 
 /// A module with some important traits to star-import.


### PR DESCRIPTION
This PR updates the dependency `cookie` from 0.5 to 0.12 in order to be no longer dependent on old versions of the openssl crate.